### PR TITLE
Fix: Clear stale relay mappings and remove config block when disabled

### DIFF
--- a/core/internal/service/relay/config_sync.go
+++ b/core/internal/service/relay/config_sync.go
@@ -440,6 +440,11 @@ func SyncRelayConfigsToPostfix(ctx context.Context) error {
 	} else {
 
 		activeConfigs = []*entity.BmRelayConfig{}
+		// Clear stale relay transport mappings to ensure fallback to original SMTP
+		_, err = g.DB().Model("bm_domain_smtp_transport").Where("atype", "relay").Delete()
+		if err != nil {
+			g.Log().Warningf(ctx, "Failed to clear relay transport mappings: %v", err)
+		}
 		g.Log().Info(ctx, "No active relay to domain mappings, relay functionality will be disabled")
 	}
 
@@ -799,6 +804,21 @@ sender_dependent_default_transport_maps = pgsql:/etc/postfix/sql/pgsql_sender_tr
 				content = content + "\n" + configBlock + "\n"
 			}
 			modified = true
+		}
+	} else {
+		// Remove the configuration block when relay is disabled
+		if hasConfigBlock {
+			blockEnd := endIndex + len(endMarker)
+			// Include trailing newline if present
+			if blockEnd < len(content) && (content[blockEnd] == '\n' || content[blockEnd] == '\r') {
+				blockEnd++
+				if blockEnd < len(content) && content[blockEnd] == '\n' {
+					blockEnd++
+				}
+			}
+			content = content[:beginIndex] + content[blockEnd:]
+			modified = true
+			g.Log().Info(nil, "Removed relay configuration block from main.cf")
 		}
 	}
 	// If there are modifications, write to the file


### PR DESCRIPTION
fixes #293 

### Purpose
When an SMTP relay is disabled or deleted, the system fails to fall back to the server's own/local SMTP and returns "mail transport unavailable" error. This occurs because:

1. **Stale database entries**: The `bm_domain_smtp_transport` table retains relay transport mappings pointing to non-existent SMTP services
2. **Orphaned Postfix config**: The `main.cf` relay configuration block (`sender_dependent_default_transport_maps`) remains active even after relay is disabled

This PR ensures proper cleanup when relay functionality is disabled, restoring expected fallback behavior.

### Implementation
**File**: `core/internal/service/relay/config_sync.go`

**Change 1** - Clear stale transport mappings (lines 443-447):
```go
// Clear stale relay transport mappings to ensure fallback to original SMTP
_, err = g.DB().Model("bm_domain_smtp_transport").Where("atype", "relay").Delete()
if err != nil {
    g.Log().Warningf(ctx, "Failed to clear relay transport mappings: %v", err)
}
```

**Change 2** - Remove relay config block from `main.cf` (lines 808-822):
```go
} else {
    // Remove the configuration block when relay is disabled
    if hasConfigBlock {
        blockEnd := endIndex + len(endMarker)
        if blockEnd < len(content) && (content[blockEnd] == '\n' || content[blockEnd] == '\r') {
            blockEnd++
            if blockEnd < len(content) && content[blockEnd] == '\n' {
                blockEnd++
            }
        }
        content = content[:beginIndex] + content[blockEnd:]
        modified = true
        g.Log().Info(nil, "Removed relay configuration block from main.cf")
    }
}
```

### Testing
- [x] Unit tests passed (`go test`)
- [x] Manual steps:
```bash
# 1. Configure and enable an SMTP relay with domain binding
# 2. Send test email → should route via relay
# 3. Disable the relay (set active=0)
# 4. Send test email → should now use local SMTP (fallback)
# 5. Verify main.cf no longer contains relay configuration block
docker exec billionmail-postfix-billionmail-1cat /etc/postfix/main.cf | grep -A4 "RELAY SERVICE"
# 6. Verify transport table is cleared
docker exec billionmail-pgsql-billionmail-1 psql -U billionmail  -d billionmail  -c "SELECT * FROM bm_domain_smtp_transport WHERE atype='relay';"
```
- [x] Impact analysis: No changes to relay-enabled functionality; only affects cleanup on disable