### PR TITLE
feat(api): return group_id in contact group create response

### DIFF
--- a/core/api/contact/v1/contact.go
+++ b/core/api/contact/v1/contact.go
@@ -86,6 +86,9 @@ type CreateGroupReq struct {
 
 type CreateGroupRes struct {
 	api_v1.StandardRes
+	Data struct {
+		GroupId int `json:"group_id" dc:"Created Group ID"`
+	} `json:"data"`
 }
 
 // ImportContactsReq Import contacts request

--- a/core/internal/controller/contact/contact_v1_create_group.go
+++ b/core/internal/controller/contact/contact_v1_create_group.go
@@ -1,11 +1,12 @@
 package contact
 
 import (
-	"billionmail-core/api/contact/v1"
+	v1 "billionmail-core/api/contact/v1"
 	"billionmail-core/internal/consts"
 	"billionmail-core/internal/service/contact"
 	"billionmail-core/internal/service/public"
 	"context"
+
 	"github.com/gogf/gf/v2/errors/gerror"
 )
 
@@ -65,6 +66,7 @@ func (c *ControllerV1) CreateGroup(ctx context.Context, req *v1.CreateGroupReq) 
 				})
 
 				res.SetSuccess(public.LangCtx(ctx, "Group created successfully"))
+				res.Data.GroupId = groupId
 				return
 			}
 			res.Code = 400
@@ -103,10 +105,13 @@ func (c *ControllerV1) CreateGroup(ctx context.Context, req *v1.CreateGroupReq) 
 	switch req.CreateType {
 	case 1:
 		res.SetSuccess(public.LangCtx(ctx, "Group created successfully"))
+		res.Data.GroupId = groupId
 	case 2:
 		res.SetSuccess(public.LangCtx(ctx, "Group created and contacts imported successfully"))
+		res.Data.GroupId = groupId
 	case 3:
 		res.SetSuccess(public.LangCtx(ctx, "Contacts imported to existing group successfully"))
+		res.Data.GroupId = groupId
 	}
 
 	return


### PR DESCRIPTION
Fixes #280
 Purpose  
The `/api/contact/group/create` endpoint currently returns success without the created group ID. Users need to query the group list to get the ID, which is inconvenient for automation and API integrations.
 Implementation  
- Added `Data` struct with `group_id` field to `CreateGroupRes` response type
- Set `res.Data.GroupId` for all 3 creation types (1, 2, 3) in the controller
 Testing  
- [x] Code compiles successfully (`go build ./api/contact/v1/... ./internal/controller/contact/...`)
- [ ] Unit tests added/updated
- [ ] Manual API testing
 API Response Example
**Before:**
{
  "code": 0,
  "message": "Group created successfully",
  "data": null
}
After:
{
  code: 0,
  message: Group created successfully,
  data: {
    group_id: 123
  }
}