### PR TITLE
fix(core): serve HTTP-01 ACME challenges via webroot provider

### DIFF
--- a/core/internal/cmd/cmd.go
+++ b/core/internal/cmd/cmd.go
@@ -183,6 +183,15 @@ var (
 							return
 						}
 
+						// Allow ACME HTTP-01 challenge requests through the
+						// SafePath gate. Let's Encrypt validation servers
+						// have no session cookie, and the challenge files
+						// are served directly by the GoFrame static handler
+						// from the webroot.
+						if strings.HasPrefix(r.URL.Path, "/.well-known/acme-challenge/") {
+							return
+						}
+
 						if r.IsFileRequest() {
 							return
 						}
@@ -294,20 +303,6 @@ var (
 				Root:    consts.ROUNDCUBE_ROOT_PATH_IN_CONTAINER,
 				Static:  consts.ROUNDCUBE_ROOT_PATH,
 			}))
-
-			// Proxy 60880 port for ACME challenge
-			ACMEChallengeProxy := httputil.NewSingleHostReverseProxy(&url.URL{
-				Scheme: "http",
-				Host:   "127.0.0.1:60880",
-			})
-			ACMEChallengeProxy.Transport = &http.Transport{
-				MaxIdleConns:        5,
-				MaxIdleConnsPerHost: 1,
-				IdleConnTimeout:     5 * time.Second,
-			}
-			s.BindHandler("/.well-known/acme-challenge/*any", func(r *ghttp.Request) {
-				ACMEChallengeProxy.ServeHTTP(r.Response.BufferWriter, r.Request)
-			})
 
 			// Proxy Rspamd GUI
 			var rspamdProxy *httputil.ReverseProxy

--- a/core/internal/service/acme/acme.go
+++ b/core/internal/service/acme/acme.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/go-acme/lego/v4/certcrypto"
 	"github.com/go-acme/lego/v4/certificate"
-	"github.com/go-acme/lego/v4/challenge/http01"
 	"github.com/go-acme/lego/v4/lego"
 	"github.com/go-acme/lego/v4/log"
 	"github.com/go-acme/lego/v4/providers/dns/alidns"
@@ -27,7 +26,9 @@ import (
 	"github.com/go-acme/lego/v4/providers/dns/cloudxns"
 	"github.com/go-acme/lego/v4/providers/dns/godaddy"
 	"github.com/go-acme/lego/v4/providers/dns/tencentcloud"
+	"github.com/go-acme/lego/v4/providers/http/webroot"
 	"github.com/go-acme/lego/v4/registration"
+	"github.com/gogf/gf/v2/frame/g"
 )
 
 type MyUser struct {
@@ -394,9 +395,17 @@ func ApplySSLWithExistingServer(ctx context.Context, domains []string, email str
 
 	// Set verification method
 	if vtype == "http" {
-		// Assume the HTTP server is already running and properly configured
-		// to handle the challenge requests
-		err = client.Challenge.SetHTTP01Provider(http01.NewProviderServer("127.0.0.1", "60880"))
+		// Serve the HTTP-01 challenge via the embedded GoFrame static file
+		// server. lego writes the token to <serverRoot>/.well-known/acme-challenge/
+		// and removes it after validation. This avoids running a second HTTP
+		// listener on 127.0.0.1:60880 (whose responses were shadowed by the
+		// static file handler in front of the bound proxy route).
+		serverRoot := g.Cfg().MustGet(ctx, "server.serverRoot", "public/dist").String()
+		webrootProvider, wErr := webroot.NewHTTPProvider(public.AbsPath(serverRoot))
+		if wErr != nil {
+			return "", "", errors.New(public.LangCtx(ctx, "Failed to init webroot provider: {}", wErr.Error()))
+		}
+		err = client.Challenge.SetHTTP01Provider(webrootProvider)
 		if err != nil {
 			return "", "", errors.New(public.LangCtx(ctx, "Failed to set HTTP verification: {}", err.Error()))
 		}


### PR DESCRIPTION
## Problem

The panel's **Apply Free Cert** UI fails with `Invalid response from http://<host>/.well-known/acme-challenge/<token>: 404` on every domain. This is reproducible on a clean install of `billionmail/core:4.9.3` with port 80 reachable and DNS pointed at the host:

```
Failed to apply for SSL certificate: error: one or more domains had a problem:
[mail.example.com] invalid authorization: acme: error: 403 ::
urn:ietf:params:acme:error:unauthorized :: <ip>:
Invalid response from http://mail.example.com/.well-known/acme-challenge/<token>: 404
```

## Root cause

Two issues compound:

1. **SafePath middleware blocks unauthenticated ACME requests.** The hook at `cmd.go` returns 404 for any non-`/api/` request without a session cookie. Let's Encrypt validation servers have no session, so they never reach the ACME handler.

2. **The static file handler shadows the ACME proxy.** `manifest/config/config.yaml` sets `fileServerEnabled: true`, which makes GoFrame's static file handler run ahead of bound handlers. Even with the SafePath gate bypassed, requests for `/.well-known/acme-challenge/<token>` are intercepted by the static handler and 404 because the file doesn't exist on disk. The bound proxy at `s.BindHandler(\"/.well-known/acme-challenge/*any\", …)` and the lego internal server at `127.0.0.1:60880` are never reached.

I confirmed (1) by adding a SafePath bypass and observing requests reach the bound handler. I confirmed (2) by adding a unique response body to the bound handler and seeing the static handler's stock `Not Found` returned instead.

## Fix

- Switch the HTTP-01 provider from `http01.NewProviderServer(\"127.0.0.1\", \"60880\")` to lego's webroot provider, pointing at `server.serverRoot`. lego writes the challenge token to `<serverRoot>/.well-known/acme-challenge/<token>` directly. The existing static handler serves it. lego removes the file after validation completes.
- Remove the now-dead 60880 reverse proxy in `cmd.go`.
- Add a `/.well-known/acme-challenge/` bypass to the SafePath middleware so LE can reach the webroot path.

The webroot path is read from config (`server.serverRoot`, defaulting to `public/dist`) instead of being hardcoded.

## Diff stats

```
core/internal/cmd/cmd.go           | 23 +++++++++--------------
core/internal/service/acme/acme.go | 17 +++++++++++++----
2 files changed, 22 insertions(+), 18 deletions(-)
```

## Verification

End-to-end test against `billionmail/core:4.9.3` with the patched binary deployed:

| Check | Result |
|---|---|
| `POST /api/ssl/apply_cert` | `{\"success\":true,\"msg\":\"Certificate applied successfully\"}` |
| `letsencrypts` row created | `status=1`, correct `not_after`, valid `subject` |
| TLS on :443 / :993 / :587 | Issuer `Let's Encrypt R12`, CN matches host |
| Cleanup | `<serverRoot>/.well-known/acme-challenge/` empty after issuance |

Tested with two domains (`mail.emudevs.gg`, `mail.synapse-themes.cc`); both issued cleanly through the panel UI.

## Notes

- No new dependency: `github.com/go-acme/lego/v4/providers/http/webroot` is part of the lego module already in `go.mod`.
- `g.Cfg().MustGet(ctx, \"server.serverRoot\", \"public/dist\")` is used so admins who customize `serverRoot` aren't broken.
- The DNS-01 paths (Cloudflare, Aliyun, Tencent, etc.) are unchanged.