### PR TITLE
fix: exclude /pmta tracking links from safepath check (fixes #338)

### DIFF
--- a/core/internal/cmd/cmd.go
+++ b/core/internal/cmd/cmd.go
@@ -202,7 +202,7 @@ var (
 			// ip whitelist middleware
 			s.Use(middleware.IPWhitelist)
 
-			// Define excluded URIs
+			// Define excluded URIs (exact match)
 			excludesURIs := map[string]struct{}{
 				"/favicon.ico":                   {},
 				"/robots.txt":                    {},
@@ -223,6 +223,12 @@ var (
 				"/subscribe_success.html":        {},
 				"/unsubscribe_success.html":      {},
 				"/subscribe_form_code.html":      {},
+				"/pmta":                          {},
+			}
+
+			// URI prefixes excluded from safe path check (tracking links, etc.)
+			excludedURIPrefixes := []string{
+				"/pmta/",
 			}
 
 			// Bind Server Hooks
@@ -243,10 +249,16 @@ var (
 							return
 						}
 
-						// check if the request is in the excluded URIs
-						if _, ok := excludesURIs[r.URL.Path]; ok {
+					// check if the request is in the excluded URIs
+					if _, ok := excludesURIs[r.URL.Path]; ok {
+						return
+					}
+
+					for _, prefix := range excludedURIPrefixes {
+						if strings.HasPrefix(r.URL.Path, prefix) {
 							return
 						}
+					}
 
 						if r.IsFileRequest() {
 							return


### PR DESCRIPTION
### Problem

When safepath is enabled, click/open tracking links (`/pmta/*`) return 404 for recipients who open emails in incognito/private windows or forwarded emails — they lack the `safe_path_pass` session cookie.

### Root Cause

The safepath middleware in `core/internal/cmd/cmd.go` blocks all requests without the `safe_path_pass` cookie. The `/pmta` tracking endpoints are not in the `excludesURIs` whitelist, so tracking links get 404.

### Fix

1. Add `/pmta` to the `excludesURIs` exact-match map
2. Add `excludedURIPrefixes` list with `/pmta/` for prefix matching — tracking links include encrypted IDs after the path prefix (e.g., `/pmta/ENCRYPTED_ID`)

### Testing

- `go build ./core/...` — compiles clean
- `go vet ./core/...` — no issues
- `go test -count=1 -short ./internal/...` — 1,275 tests pass

### Related

Fixes #338

Signed-off-by: srmdn <mail@saidwp.com>