### PR TITLE
fix(multi_ip_domain): ensure destination dir exists before chroot cp

### DIFF
--- a/core/internal/service/multi_ip_domain/config_manager.go
+++ b/core/internal/service/multi_ip_domain/config_manager.go
@@ -178,15 +178,21 @@ func (m *ConfigManager) updateDockerCompose(ctx context.Context, configs []map[s
 	}
 	defer dk.Close()
 
-	// Step 1: 复制宿主机的 docker-compose.yml 到宿主机的 core-data 目录
-	// 注意：这里目标路径使用宿主机的路径，因为 chroot /host_root 看到的是宿主机文件系
+	// Step 1: Ensure the destination directory exists on the host, then copy
+	// the original docker-compose.yml to a temporary location for modification.
+	mkdirCmd := []string{
+		"/bin/sh", "-c",
+		fmt.Sprintf(`chroot /host_root mkdir -p "%s"`, gfile.Dir(hostTempDockerComposePath)),
+	}
+	dk.ExecHostCommand(ctx, mkdirCmd)
+
 	copyCmd := []string{
 		"/bin/sh", "-c",
 		fmt.Sprintf(`chroot /host_root cp "%s" "%s"`, originalPath, hostTempDockerComposePath),
 	}
 	result, err := dk.ExecHostCommand(ctx, copyCmd)
 	if err != nil || result.ExitCode != 0 {
-		return gerror.New("failed to copy original configuration file, please check path and permissions")
+		return gerror.Newf("failed to copy original configuration file: %v (src=%s, dst=%s)", err, originalPath, hostTempDockerComposePath)
 	}
 
 	// Step 2: 从容器内路径读取复制的文件
@@ -219,7 +225,13 @@ func (m *ConfigManager) updateDockerCompose(ctx context.Context, configs []map[s
 		return fmt.Errorf("failed to write temporary output file: %v", err)
 	}
 
-	// 然后从宿主机临时位置复制到最终目标位置
+	// Ensure the output directory exists on the host, then copy the generated file.
+	mkdirOutputCmd := []string{
+		"/bin/sh", "-c",
+		fmt.Sprintf(`chroot /host_root mkdir -p "%s"`, gfile.Dir(outputPath)),
+	}
+	dk.ExecHostCommand(ctx, mkdirOutputCmd)
+
 	copyOutputCmd := []string{
 		"/bin/sh", "-c",
 		fmt.Sprintf(`chroot /host_root cp "%s" "%s"`, hostTempOutputPath, outputPath),
@@ -230,7 +242,7 @@ func (m *ConfigManager) updateDockerCompose(ctx context.Context, configs []map[s
 		if gfile.Exists(tempOutputPath) {
 			os.Remove(tempOutputPath)
 		}
-		return gerror.New("failed to copy output file to destination")
+		return gerror.Newf("failed to copy output file to destination: %v", err)
 	}
 
 	// Cleanup temporary output file


### PR DESCRIPTION
# fix(multi_ip_domain): ensure destination dir exists before chroot cp

## Purpose

The multi-IP domain apply feature fails in managed Docker environments (e.g. aaPanel) because `chroot /host_root cp` attempts to copy `docker-compose.yml` to a destination directory that doesn't exist on the host. The `hostDataPath` derived from `public.HostWorkDir + "core-data"` may not match the actual volume mount structure, causing the copy to fail with:

```
failed to copy original configuration file, please check path and permissions
```

## Implementation

Added `mkdir -p` via `chroot /host_root` before each `chroot /host_root cp` in `updateDockerCompose()` to ensure the destination parent directory exists. Also improved error messages to include source and destination paths for easier debugging.

**File changed:** `core/internal/service/multi_ip_domain/config_manager.go`

**Changes:**
- Before copying `docker-compose.yml` to temp location: ensure `gfile.Dir(hostTempDockerComposePath)` exists on host
- Before copying generated `docker-compose_addnetwork.yml` to output: ensure `gfile.Dir(outputPath)` exists on host
- Error messages now include `err`, `src`, and `dst` paths for debugging

## Testing

- [x] Reproduced the bug on aaPanel 7.x with BillionMail 4.9.5 installed via DK framework
- [x] Verified the fix resolves the `failed to copy original configuration file` error
- [x] Verified `docker-compose_addnetwork.yml` is generated correctly after fix
- [x] Manual steps:
  ```bash
  # 1. Configure multi-IP domain in BillionMail UI
  # 2. Click "Get Command" → no longer shows copy error
  # 3. docker-compose_addnetwork.yml is generated in APP_PATH
  ```

## Additional Context

- **Fixes** issue where `chroot /host_root cp` fails because `public.HostWorkDir` points to the host's `APP_PATH` (e.g. `/www/dk_project/dk_app/billionmail/billionmail`), but the `core-data` subdirectory doesn't exist at that location in aaPanel installations — it's nested under `data/core-data`. The `mkdir -p` ensures the copy target path is valid regardless of directory layout.
- **No breaking changes** — the `mkdir -p` is idempotent and won't fail if the directory already exists.