### PR TITLE
Fix the broken star history chart

### DIFF
--- a/README-tr.md
+++ b/README-tr.md
@@ -143,7 +143,7 @@ cd /opt && git clone https://github.com/aaPanel/BillionMail && cd BillionMail &&
 
 ## Yıldız Geçmişi
 
-[![Star History Chart](https://api.star-history.com/svg?repos=aapanel/billionmail&type=Date)](https://www.star-history.com/#aapanel/billionmail&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=aapanel/billionmail&type=Date)](https://star-history.dera.page/#aapanel/billionmail&Date)
 
 ## Lisans
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ cd /opt && git clone https://github.com/aaPanel/BillionMail && cd BillionMail &&
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=aapanel/billionmail&type=Date)](https://www.star-history.com/#aapanel/billionmail&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=aapanel/billionmail&type=Date)](https://star-history.dera.page/#aapanel/billionmail&Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the underlying service relies on GitHub stargazer API restrictions. This change points the chart to the working alternative so it displays correctly again.